### PR TITLE
Prevent column duplication in read_frame

### DIFF
--- a/django_pandas/io.py
+++ b/django_pandas/io.py
@@ -101,6 +101,8 @@ def read_frame(qs, fieldnames=(), index_col=None, coerce_float=False,
         fields = qs.model._meta.fields
         fieldnames = [f.name for f in fields]
 
+    fieldnames = pd.unique(fieldnames)
+
     if is_values_queryset(qs):
         recs = list(qs)
     else:

--- a/django_pandas/tests/test_io.py
+++ b/django_pandas/tests/test_io.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 import django
-from django.db.models import Sum
+from django.db.models import Sum, F
 import pandas as pd
 import numpy as np
 from .models import MyModel, Trader, Security, TradeLog, TradeLogNote, MyModelChoice, Portfolio
@@ -55,6 +55,15 @@ class IOTest(TestCase):
         self.assertEqual(list(df.columns),
                          ['index_col', 'col1', 'scol1', 'ecol1'])
         self.assertEqual(list(df["col1"]), list(df["scol1"]))
+
+    def test_duplicate_annotation(self):
+        qs = MyModel.objects.all()
+        qs = qs.values('index_col')
+        qs = qs.annotate(col1=F('col1'))
+        qs = qs.values()
+        df = read_frame(qs)
+        self.assertEqual(list(df.columns),
+                         ['id', 'index_col', 'col1', 'col2', 'col3', 'col4'])
 
     def test_choices(self):
 


### PR DESCRIPTION
- Prevents duplicate columns in read_frame dataframe due to annotation reusing model field name.
- Preserves ordering of field names as required by tests
- Passes all tests